### PR TITLE
Throwable needed for Error.pm

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,5 +14,6 @@ requires 'HTTP::Request::Common' => 0;
 requires 'MIME::Base64'          => 0;
 requires 'URI::Escape'           => 0;
 requires 'JSON'                  => 0;
+requires 'Throwable'             => 0;
 
 WriteAll;


### PR DESCRIPTION
I happened to not have Throwable pre-installed and noticed it's a missing dep. for Error.pm's role. I added it to the Makefile.PL. Thanks for writing this library.
