### PR TITLE
Add support for partial refunds via second parameter on refund_charge call.

### DIFF
--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -101,8 +101,16 @@ Charges: {
 
     method refund_charge {
         my $id = shift || die "A charge ID is required";;
+        my $amount = shift;
         $id = $id->id if ref($id);
-        return $self->_post("charges/$id/refund");
+        
+        if($amount) {
+            $amount = "?amount=$amount";
+        } else {
+            $amount = '';
+        }
+        
+        return $self->_post("charges/$id/refund" . $amount);
     }
 
     method get_charges {

--- a/lib/Net/Stripe/Charge.pm
+++ b/lib/Net/Stripe/Charge.pm
@@ -14,6 +14,7 @@ has 'description' => (is => 'ro', isa => 'Str');
 has 'livemode'    => (is => 'ro', isa => 'Bool');
 has 'paid'        => (is => 'ro', isa => 'Bool');
 has 'refunded'    => (is => 'ro', isa => 'Bool');
+has 'amount_refunded' => (is => 'ro', isa => 'Int');
 
 method form_fields {
     return (

--- a/t/live.t
+++ b/t/live.t
@@ -157,10 +157,18 @@ Charges: {
 
         # Refund a charge
         my $charge3;
+        # partial refund
+        lives_ok { $charge = $stripe->refund_charge($charge->id, 1000) }
+            'refunding a charge works';
+        is $charge->id, $charge->id, 'returned charge object matches id';
+        is $charge->amount_refunded, 1000, 'partial refund $10';
+        ok !$charge->refunded, 'charge not yet fully refunded';
+        # fully refund
         lives_ok { $charge = $stripe->refund_charge($charge->id) }
-            'Refunding a charge works';
+            'refunding remainder of charge';
         is $charge->id, $charge->id, 'returned charge object matches id';
         ok $charge->refunded, 'charge is refunded';
+        ok $charge->paid, 'charge was paid';
         ok $charge->paid, 'charge was paid';
 
         # Fetch list of charges


### PR DESCRIPTION
Add optional second parameter to redund_charge which is an amount in cents to refund.
Add amount_refunded field to Charge which is filled by the API on return from a
 partial refund API call.
Add live test of partial and total (no amount specified) refund.
