### PR TITLE
Allow null attributes in API responses

### DIFF
--- a/lib/Net/Stripe/Card.pm
+++ b/lib/Net/Stripe/Card.pm
@@ -6,24 +6,24 @@ use methods;
 union 'StripeCard', ['Str', 'Net::Stripe::Card', 'Net::Stripe::Token'];
 
 # Input fields
-has 'number'          => (is => 'ro', isa => 'Str');
-has 'cvc'             => (is => 'ro', isa => 'Int');
-has 'name'            => (is => 'ro', isa => 'Str');
-has 'address_line1'   => (is => 'ro', isa => 'Str');
-has 'address_line2'   => (is => 'ro', isa => 'Str');
-has 'address_zip'     => (is => 'ro', isa => 'Str');
-has 'address_state'   => (is => 'ro', isa => 'Str');
-has 'address_country' => (is => 'ro', isa => 'Str');
+has 'number'          => (is => 'ro', isa => 'Maybe[Str]');
+has 'cvc'             => (is => 'ro', isa => 'Maybe[Int]');
+has 'name'            => (is => 'ro', isa => 'Maybe[Str]');
+has 'address_line1'   => (is => 'ro', isa => 'Maybe[Str]');
+has 'address_line2'   => (is => 'ro', isa => 'Maybe[Str]');
+has 'address_zip'     => (is => 'ro', isa => 'Maybe[Str]');
+has 'address_state'   => (is => 'ro', isa => 'Maybe[Str]');
+has 'address_country' => (is => 'ro', isa => 'Maybe[Str]');
 
 # Both input and output
-has 'exp_month'       => (is => 'ro', isa => 'Int', required => 1);
-has 'exp_year'        => (is => 'ro', isa => 'Int', required => 1);
+has 'exp_month'       => (is => 'ro', isa => 'Maybe[Int]', required => 1);
+has 'exp_year'        => (is => 'ro', isa => 'Maybe[Int]', required => 1);
 
 # Output fields
-has 'country'         => (is => 'ro', isa => 'Str');
-has 'cvc_check'       => (is => 'ro', isa => 'Str');
-has 'last4'           => (is => 'ro', isa => 'Str');
-has 'type'            => (is => 'ro', isa => 'Str');
+has 'country'         => (is => 'ro', isa => 'Maybe[Str]');
+has 'cvc_check'       => (is => 'ro', isa => 'Maybe[Str]');
+has 'last4'           => (is => 'ro', isa => 'Maybe[Str]');
+has 'type'            => (is => 'ro', isa => 'Maybe[Str]');
 
 method form_fields {
     return (

--- a/lib/Net/Stripe/Charge.pm
+++ b/lib/Net/Stripe/Charge.pm
@@ -3,18 +3,18 @@ use Moose;
 use methods;
 extends 'Net::Stripe::Resource';
 
-has 'id'          => (is => 'ro', isa => 'Str');
-has 'created'     => (is => 'ro', isa => 'Int');
-has 'fee'         => (is => 'ro', isa => 'Int');
-has 'amount'      => (is => 'ro', isa => 'Int', required => 1);
-has 'currency'    => (is => 'ro', isa => 'Str', required => 1);
-has 'customer'    => (is => 'ro', isa => 'Str');
-has 'card'        => (is => 'ro', isa => 'StripeCard');
-has 'description' => (is => 'ro', isa => 'Str');
-has 'livemode'    => (is => 'ro', isa => 'Bool');
-has 'paid'        => (is => 'ro', isa => 'Bool');
-has 'refunded'    => (is => 'ro', isa => 'Bool');
-has 'amount_refunded' => (is => 'ro', isa => 'Int');
+has 'id'          => (is => 'ro', isa => 'Maybe[Str]');
+has 'created'     => (is => 'ro', isa => 'Maybe[Int]');
+has 'fee'         => (is => 'ro', isa => 'Maybe[Int]');
+has 'amount'      => (is => 'ro', isa => 'Maybe[Int]', required => 1);
+has 'currency'    => (is => 'ro', isa => 'Maybe[Str]', required => 1);
+has 'customer'    => (is => 'ro', isa => 'Maybe[Str]');
+has 'card'        => (is => 'ro', isa => 'Maybe[StripeCard]');
+has 'description' => (is => 'ro', isa => 'Maybe[Str]');
+has 'livemode'    => (is => 'ro', isa => 'Maybe[Bool]');
+has 'paid'        => (is => 'ro', isa => 'Maybe[Bool]');
+has 'refunded'    => (is => 'ro', isa => 'Maybe[Bool]');
+has 'amount_refunded' => (is => 'ro', isa => 'Maybe[Int]');
 
 method form_fields {
     return (

--- a/lib/Net/Stripe/Coupon.pm
+++ b/lib/Net/Stripe/Coupon.pm
@@ -6,12 +6,12 @@ extends 'Net::Stripe::Resource';
 
 union 'StripeCoupon', ['Str', 'Net::Stripe::Coupon'];
 
-has 'id'                 => (is => 'rw', isa => 'Str');
-has 'percent_off'        => (is => 'rw', isa => 'Int', required => 1);
-has 'duration'           => (is => 'rw', isa => 'Str', required => 1);
-has 'duration_in_months' => (is => 'rw', isa => 'Int');
-has 'max_redemptions'    => (is => 'rw', isa => 'Int');
-has 'redeem_by'          => (is => 'rw', isa => 'Int');
+has 'id'                 => (is => 'rw', isa => 'Maybe[Str]');
+has 'percent_off'        => (is => 'rw', isa => 'Maybe[Int]', required => 1);
+has 'duration'           => (is => 'rw', isa => 'Maybe[Str]', required => 1);
+has 'duration_in_months' => (is => 'rw', isa => 'Maybe[Int]');
+has 'max_redemptions'    => (is => 'rw', isa => 'Maybe[Int]');
+has 'redeem_by'          => (is => 'rw', isa => 'Maybe[Int]');
 
 method form_fields {
     return (

--- a/lib/Net/Stripe/Customer.pm
+++ b/lib/Net/Stripe/Customer.pm
@@ -4,18 +4,18 @@ use methods;
 extends 'Net::Stripe::Resource';
 
 # Customer creation args
-has 'email'       => (is => 'rw', isa => 'Str');
-has 'description' => (is => 'rw', isa => 'Str');
-has 'trial_end'   => (is => 'rw', isa => 'Int');
-has 'card'        => (is => 'rw', isa => 'StripeCard');
-has 'plan'        => (is => 'ro', isa => 'StripePlan');
-has 'coupon'      => (is => 'rw', isa => 'StripeCoupon');
+has 'email'       => (is => 'rw', isa => 'Maybe[Str]');
+has 'description' => (is => 'rw', isa => 'Maybe[Str]');
+has 'trial_end'   => (is => 'rw', isa => 'Maybe[Int]');
+has 'card'        => (is => 'rw', isa => 'Maybe[StripeCard]');
+has 'plan'        => (is => 'ro', isa => 'Maybe[StripePlan]');
+has 'coupon'      => (is => 'rw', isa => 'Maybe[StripeCoupon]');
 
 # API object args
-has 'id'           => (is => 'ro', isa => 'Str');
-has 'deleted'      => (is => 'ro', isa => 'Bool', default => 0);
-has 'active_card'  => (is => 'ro', isa => 'StripeCard');
-has 'subscription' => (is => 'ro', isa => 'Net::Stripe::Subscription');
+has 'id'           => (is => 'ro', isa => 'Maybe[Str]');
+has 'deleted'      => (is => 'ro', isa => 'Maybe[Bool]', default => 0);
+has 'active_card'  => (is => 'ro', isa => 'Maybe[StripeCard]');
+has 'subscription' => (is => 'ro', isa => 'Maybe[Net::Stripe::Subscription]');
 
 method form_fields {
     return (

--- a/lib/Net/Stripe/Error.pm
+++ b/lib/Net/Stripe/Error.pm
@@ -3,10 +3,10 @@ use Moose;
 with 'Throwable';
 use namespace::clean -except => 'meta';
 
-has 'type'    => (is => 'ro', isa => 'Str', required => 1);
-has 'message' => (is => 'ro', isa => 'Str', required => 1);
-has 'code'    => (is => 'ro', isa => 'Str');
-has 'param'   => (is => 'ro', isa => 'Str');
+has 'type'    => (is => 'ro', isa => 'Maybe[Str]', required => 1);
+has 'message' => (is => 'ro', isa => 'Maybe[Str]', required => 1);
+has 'code'    => (is => 'ro', isa => 'Maybe[Str]');
+has 'param'   => (is => 'ro', isa => 'Maybe[Str]');
 
 use overload fallback => 1,
     '""' => sub {

--- a/lib/Net/Stripe/Invoice.pm
+++ b/lib/Net/Stripe/Invoice.pm
@@ -3,10 +3,10 @@ use Moose;
 use methods;
 extends 'Net::Stripe::Resource';
 
-has 'id'       => (is => 'ro', isa => 'Str');
-has 'created'  => (is => 'ro', isa => 'Int');
-has 'total'    => (is => 'ro', isa => 'Int',              required => 1);
-has 'subtotal' => (is => 'ro', isa => 'Int',              required => 1);
+has 'id'       => (is => 'ro', isa => 'Maybe[Str]');
+has 'created'  => (is => 'ro', isa => 'Maybe[Int]');
+has 'total'    => (is => 'ro', isa => 'Maybe[Int]',              required => 1);
+has 'subtotal' => (is => 'ro', isa => 'Maybe[Int]',              required => 1);
 has 'lines'    => (is => 'ro', isa => 'ArrayRef[Object]', required => 1);
 
 has 'invoiceitems' =>

--- a/lib/Net/Stripe/Invoiceitem.pm
+++ b/lib/Net/Stripe/Invoiceitem.pm
@@ -3,12 +3,12 @@ use Moose;
 use methods;
 extends 'Net::Stripe::Resource';
 
-has 'id'                => (is => 'ro', isa => 'Str');
-has 'customer'          => (is => 'ro', isa => 'Str', required => 1);
-has 'amount'            => (is => 'rw', isa => 'Int', required => 1);
-has 'currency'          => (is => 'rw', isa => 'Str', required => 1);
-has 'description'       => (is => 'rw', isa => 'Str');
-has 'date'              => (is => 'ro', isa => 'Int');
+has 'id'                => (is => 'ro', isa => 'Maybe[Str]');
+has 'customer'          => (is => 'ro', isa => 'Maybe[Str]', required => 1);
+has 'amount'            => (is => 'rw', isa => 'Maybe[Int]', required => 1);
+has 'currency'          => (is => 'rw', isa => 'Maybe[Str]', required => 1);
+has 'description'       => (is => 'rw', isa => 'Maybe[Str]');
+has 'date'              => (is => 'ro', isa => 'Maybe[Int]');
 
 method form_fields {
     return (

--- a/lib/Net/Stripe/Plan.pm
+++ b/lib/Net/Stripe/Plan.pm
@@ -6,12 +6,12 @@ extends 'Net::Stripe::Resource';
 
 union 'StripePlan', ['Str', 'Net::Stripe::Plan'];
 
-has 'id'                => (is => 'ro', isa => 'Str', required => 1);
-has 'amount'            => (is => 'ro', isa => 'Int', required => 1);
-has 'currency'          => (is => 'ro', isa => 'Str', required => 1);
-has 'interval'          => (is => 'ro', isa => 'Str', required => 1);
-has 'name'              => (is => 'ro', isa => 'Str', required => 1);
-has 'trial_period_days' => (is => 'ro', isa => 'Int');
+has 'id'                => (is => 'ro', isa => 'Maybe[Str]', required => 1);
+has 'amount'            => (is => 'ro', isa => 'Maybe[Int]', required => 1);
+has 'currency'          => (is => 'ro', isa => 'Maybe[Str]', required => 1);
+has 'interval'          => (is => 'ro', isa => 'Maybe[Str]', required => 1);
+has 'name'              => (is => 'ro', isa => 'Maybe[Str]', required => 1);
+has 'trial_period_days' => (is => 'ro', isa => 'Maybe[Int]');
 
 method form_fields {
     return (

--- a/lib/Net/Stripe/Subscription.pm
+++ b/lib/Net/Stripe/Subscription.pm
@@ -3,22 +3,22 @@ use Moose;
 use methods;
 extends 'Net::Stripe::Resource';
 
-has 'plan' => (is => 'ro', isa => 'StripePlan', required => 1);
-has 'coupon'    => (is => 'ro', isa => 'StripeCoupon');
-has 'prorate'   => (is => 'ro', isa => 'Bool');
-has 'trial_end' => (is => 'ro', isa => 'Int');
-has 'card'      => (is => 'ro', isa => 'StripeCard');
+has 'plan' => (is => 'ro', isa => 'Maybe[StripePlan]', required => 1);
+has 'coupon'    => (is => 'ro', isa => 'Maybe[StripeCoupon]');
+has 'prorate'   => (is => 'ro', isa => 'Maybe[Bool]');
+has 'trial_end' => (is => 'ro', isa => 'Maybe[Int]');
+has 'card'      => (is => 'ro', isa => 'Maybe[StripeCard]');
 
 # Other fields returned by the API
-has 'customer'             => (is => 'ro', isa => 'Str');
-has 'status'               => (is => 'ro', isa => 'Str');
-has 'start'                => (is => 'ro', isa => 'Int');
-has 'canceled_at'          => (is => 'ro', isa => 'Int');
-has 'ended_at'             => (is => 'ro', isa => 'Int');
-has 'current_period_start' => (is => 'ro', isa => 'Int');
-has 'current_period_end'   => (is => 'ro', isa => 'Int');
-has 'trial_start'          => (is => 'ro', isa => 'Str');
-has 'trial_end'            => (is => 'ro', isa => 'Str');
+has 'customer'             => (is => 'ro', isa => 'Maybe[Str]');
+has 'status'               => (is => 'ro', isa => 'Maybe[Str]');
+has 'start'                => (is => 'ro', isa => 'Maybe[Int]');
+has 'canceled_at'          => (is => 'ro', isa => 'Maybe[Int]');
+has 'ended_at'             => (is => 'ro', isa => 'Maybe[Int]');
+has 'current_period_start' => (is => 'ro', isa => 'Maybe[Int]');
+has 'current_period_end'   => (is => 'ro', isa => 'Maybe[Int]');
+has 'trial_start'          => (is => 'ro', isa => 'Maybe[Str]');
+has 'trial_end'            => (is => 'ro', isa => 'Maybe[Str]');
 
 
 method form_fields {

--- a/lib/Net/Stripe/Token.pm
+++ b/lib/Net/Stripe/Token.pm
@@ -4,15 +4,15 @@ use methods;
 extends 'Net::Stripe::Resource';
 
 # Args for creating a Token
-has 'card'        => (is => 'ro', isa => 'Net::Stripe::Card', required => 1);
-has 'amount'      => (is => 'ro', isa => 'Int');
-has 'currency'    => (is => 'ro', isa => 'Str');
+has 'card'        => (is => 'ro', isa => 'Maybe[Net::Stripe::Card]', required => 1);
+has 'amount'      => (is => 'ro', isa => 'Maybe[Int]');
+has 'currency'    => (is => 'ro', isa => 'Maybe[Str]');
 
 # Args returned by the API
-has 'id'          => (is => 'ro', isa => 'Str');
-has 'created'     => (is => 'ro', isa => 'Int');
-has 'used'        => (is => 'ro', isa => 'Bool');
-has 'livemode'    => (is => 'ro', isa => 'Bool');
+has 'id'          => (is => 'ro', isa => 'Maybe[Str]');
+has 'created'     => (is => 'ro', isa => 'Maybe[Int]');
+has 'used'        => (is => 'ro', isa => 'Maybe[Bool]');
+has 'livemode'    => (is => 'ro', isa => 'Maybe[Bool]');
 
 method form_fields {
     return (


### PR DESCRIPTION
The Stripe API now returns all attributes of objects, whether they are `null` or not. The API change only affects new accounts, but was breaking this module for new users.
