### PR TITLE
Make tests pass, new ability to add metadata to customers

### DIFF
--- a/lib/Net/Stripe/SubscriptionList.pm
+++ b/lib/Net/Stripe/SubscriptionList.pm
@@ -4,7 +4,7 @@ use methods;
 extends 'Net::Stripe::Resource';
 
 has 'object' => (is => 'ro', isa => 'Str');
-has 'count'  => (is => 'ro', isa => 'Int');
+has 'count'  => (is => 'ro', isa => 'Int'); # no longer included by default, see note below
 has 'url'    => (is => 'ro', isa => 'Str');
 has 'data'   => (is => 'ro', isa => 'ArrayRef[Net::Stripe::Subscription]');
 
@@ -14,3 +14,9 @@ method form_fields {
 
 __PACKAGE__->meta->make_immutable;
 1;
+
+__END__
+From the Stripe Change Log:
+2014-03-28
+Remove count property from list responses, replacing it with the optional property total_count. 
+You can request that total_count be included in your responses by specifying include[]=total_count.


### PR DESCRIPTION
Also includes patches from two other GitHub forks which don't seem to have been merged yet. 
