### PR TITLE
Fixes for methods using an old interface to _post

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -26,11 +26,11 @@ version 0.18
 
  # ... and the api mirrors https://stripe.com/docs/api
  # Charges: post_charge() get_charge() refund_charge() get_charges()
- # Customer: post_customer()
+ # Customer: post_customer() 
 
 =head1 DESCRIPTION
 
-This module is a wrapper around the Stripe.com HTTP API.  Methods are
+This module is a wrapper around the Stripe.com HTTP API.  Methods are 
 generally named after the HTTP method and the object name.
 
 This method returns Moose objects for responses from the API.
@@ -375,7 +375,7 @@ L<https://stripe.com/docs/api#list_cards>
 
 =over
 
-=item * customer - L<Net::Stripe::Customer> or Str
+=item * customer - L<Net::Stripe::Customer> or Str 
 
 =item * ending_before - Str, optional
 
@@ -419,7 +419,7 @@ L<https://stripe.com/docs/api#create_subscription>
 
 =item * customer - L<Net::Stripe::Customer>
 
-=item * subscription - L<Net::Stripe::Subscription> or Str
+=item * subscription - L<Net::Stripe::Subscription> or Str 
 
 =item * card - L<Net::Stripe::Card>, L<Net::Stripe::Token>, Str or HashRef, default card for the customer, optional
 
@@ -463,9 +463,9 @@ L<https://stripe.com/docs/api#cancel_subscription>
 
 =over
 
-=item * customer - L<Net::Stripe::Customer> or Str
+=item * customer - L<Net::Stripe::Customer> or Str 
 
-=item * subscription - L<Net::Stripe::Subscription> or Str
+=item * subscription - L<Net::Stripe::Subscription> or Str 
 
 =item * at_period_end - Bool, optional
 
@@ -485,7 +485,7 @@ L<https://stripe.com/docs/api#create_card_token>
 
 =over
 
-=item card - L<Net::Stripe::Card> or HashRef
+=item card - L<Net::Stripe::Card> or HashRef 
 
 =back
 
@@ -693,7 +693,7 @@ Update an invoice
 
 =over
 
-=item * invoice - L<Net::Stripe::Invoice>, Str
+=item * invoice - L<Net::Stripe::Invoice>, Str 
 
 =item * application_fee - Int - optional
 
@@ -765,7 +765,7 @@ L<https://stripe.com/docs/api#create_invoice>
 
 =over
 
-=item * customer - L<Net::Stripe::Customer>, Str
+=item * customer - L<Net::Stripe::Customer>, Str 
 
 =item * application_fee - Int - optional
 
@@ -925,17 +925,11 @@ Rusty Conover
 
 =head1 CONTRIBUTORS
 
-=for stopwords Andrew Solomon Tom Eliaz Brian Collins Devin M. Certas Dimitar Petrov Dylan Reinhold Jonathan "Duke" Leto Luke Closs Olaf Alders Rusty Conover Sachin Sebastian
-
 =over 4
 
 =item *
 
 Andrew Solomon <andrew@illywhacker.net>
-
-=item *
-
-Tom Eliaz <tom@tomeliaz.com>
 
 =item *
 
@@ -972,6 +966,10 @@ Rusty Conover <rusty@luckydinosaur.com>
 =item *
 
 Sachin Sebastian <sachinjsk@users.noreply.github.com>
+
+=item *
+
+Tom Eliaz <tom@tomeliaz.com>
 
 =back
 

--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -42,11 +42,11 @@ use Net::Stripe::LineItem;
 
  # ... and the api mirrors https://stripe.com/docs/api
  # Charges: post_charge() get_charge() refund_charge() get_charges()
- # Customer: post_customer()
+ # Customer: post_customer() 
 
 =head1 DESCRIPTION
 
-This module is a wrapper around the Stripe.com HTTP API.  Methods are
+This module is a wrapper around the Stripe.com HTTP API.  Methods are 
 generally named after the HTTP method and the object name.
 
 This method returns Moose objects for responses from the API.
@@ -85,7 +85,7 @@ Create a new charge
 
 L<https://stripe.com/docs/api#create_charge>
 
-=over
+=over 
 
 =item * amount - Int - amount to charge
 
@@ -117,7 +117,7 @@ Retrieve a charge.
 
 L<https://stripe.com/docs/api#retrieve_charge>
 
-=over
+=over 
 
 =item * charge_id - Str - charge id to retrieve
 
@@ -133,7 +133,7 @@ Refunds a charge
 
 L<https://stripe.com/docs/api#refund_charge>
 
-=over
+=over 
 
 =item * charge - L<Net::Stripe::Charge> or Str - charge or charge_id to refund
 
@@ -151,7 +151,7 @@ Returns a L<Net::Stripe::List> object containing L<Net::Stripe::Charge> objects.
 
 L<https://stripe.com/docs/api#list_charges>
 
-=over
+=over 
 
 =item * created - HashRef - created conditions to match, optional
 
@@ -203,25 +203,25 @@ Charges: {
         if (ref($charge)) {
             $charge = $charge->id;
         }
-
+        
         if($amount) {
             $amount = "?amount=$amount";
         } else {
             $amount = '';
         }
-
+        
         return $self->_post("charges/$charge/refund" . $amount);
     }
 
-    method get_charges(HashRef :$created?,
+    method get_charges(HashRef :$created?, 
                        Net::Stripe::Customer|Str :$customer?,
-                       Str :$ending_before?,
-                       Int :$limit?,
+                       Str :$ending_before?, 
+                       Int :$limit?, 
                        Str :$starting_after?) {
         if (ref($customer)) {
             $customer = $customer->id;
         }
-        $self->_get_collections('charges',
+        $self->_get_collections('charges', 
                                 created => $created,
                                 customer => $customer,
                                 ending_before => $ending_before,
@@ -238,7 +238,7 @@ Retrieve a balance transaction
 
 L<https://stripe.com/docs/api#retrieve_balance_transaction>
 
-=over
+=over 
 
 =item * id - Str - balance transaction ID to retrieve.
 
@@ -248,7 +248,7 @@ Returns a L<Net::Stripe::BalanceTransaction>
 
   $stripe->get_balance_transaction(id => 'id');
 
-=cut
+=cut 
 
 
 BalanceTransactions: {
@@ -286,7 +286,7 @@ L<https://stripe.com/docs/api#create_customer>
 
 =item * trial_end - Int or Str, optional
 
-=back
+=back 
 
 Returns a L<Net::Stripe::Customer> object
 
@@ -379,16 +379,16 @@ Customers: {
                          Str :$coupon?,
                          Str :$default_card?,
                          Str :$description?,
-                         Str :$email?,
-                         HashRef :$metadata?,
-                         Str :$plan?,
-                         Int :$quantity?,
+                         Str :$email?, 
+                         HashRef :$metadata?, 
+                         Str :$plan?, 
+                         Int :$quantity?, 
                          Int|Str :$trial_end?) {
 
         if (defined($card) && ref($card) eq 'HASH') {
             $card = Net::Stripe::Card->new($card);
-        }
-
+        } 
+        
         if (ref($customer) eq 'Net::Stripe::Customer') {
             return $self->_post("customers/" . $customer->id, $customer);
         } elsif (defined($customer)) {
@@ -400,7 +400,7 @@ Customers: {
                 email => $email,
                 metadata => $metadata,
             );
-
+    
             return $self->_post("customers/" . $customer, _defined_arguments(\%args));
         }
 
@@ -417,14 +417,14 @@ Customers: {
         return $self->_post('customers', $customer);
     }
 
-    method list_subscriptions(Net::Stripe::Customer|Str :$customer,
-                              Str :$ending_before?,
-                              Int :$limit?,
+    method list_subscriptions(Net::Stripe::Customer|Str :$customer, 
+                              Str :$ending_before?, 
+                              Int :$limit?, 
                               Str :$starting_after?) {
         if (ref($customer)) {
             $customer = $customer->id;
         }
-        return $self->_get_collections("customers/$customer/subscriptions",
+        return $self->_get_collections("customers/$customer/subscriptions", 
                            ending_before => $ending_before,
                            limit => $limit,
                            starting_after => $starting_after
@@ -443,7 +443,7 @@ Customers: {
     }
 
     method get_customers(HashRef :$created?, Str :$ending_before?, Int :$limit?, Str :$starting_after?) {
-        $self->_get_collections('customers',
+        $self->_get_collections('customers', 
                                 created => $created,
                                 ending_before => $ending_before,
                                 limit => $limit,
@@ -496,7 +496,7 @@ L<https://stripe.com/docs/api#list_cards>
 
 =over
 
-=item * customer - L<Net::Stripe::Customer> or Str
+=item * customer - L<Net::Stripe::Customer> or Str 
 
 =item * ending_before - Str, optional
 
@@ -531,7 +531,7 @@ Returns a L<Net::Stripe::Card>.
 =cut
 
 Cards: {
-    method get_card(Net::Stripe::Customer|Str :$customer,
+    method get_card(Net::Stripe::Customer|Str :$customer, 
                     Str :$card_id) {
         if (ref($customer)) {
             $customer = $customer->id;
@@ -540,15 +540,15 @@ Cards: {
     }
 
     method get_cards(Net::Stripe::Customer|Str $customer,
-                     HashRef :$created?,
-                     Str :$ending_before?,
-                     Int :$limit?,
+                     HashRef :$created?, 
+                     Str :$ending_before?, 
+                     Int :$limit?, 
                      Str :$starting_after?) {
         if (ref($customer)) {
             $customer = $customer->id;
         }
 
-        $self->_get_collections('cards',
+        $self->_get_collections('cards', 
                                 id => $customer,
                                 created => $created,
                                 ending_before => $ending_before,
@@ -556,7 +556,7 @@ Cards: {
                                 starting_after => $starting_after);
     }
 
-    method post_card(Net::Stripe::Customer|Str :$customer,
+    method post_card(Net::Stripe::Customer|Str :$customer, 
                      HashRef|Net::Stripe::Card :$card) {
         if (ref($customer)) {
             $customer = $customer->id;
@@ -597,7 +597,7 @@ L<https://stripe.com/docs/api#create_subscription>
 
 =item * customer - L<Net::Stripe::Customer>
 
-=item * subscription - L<Net::Stripe::Subscription> or Str
+=item * subscription - L<Net::Stripe::Subscription> or Str 
 
 =item * card - L<Net::Stripe::Card>, L<Net::Stripe::Token>, Str or HashRef, default card for the customer, optional
 
@@ -641,9 +641,9 @@ L<https://stripe.com/docs/api#cancel_subscription>
 
 =over
 
-=item * customer - L<Net::Stripe::Customer> or Str
+=item * customer - L<Net::Stripe::Customer> or Str 
 
-=item * subscription - L<Net::Stripe::Subscription> or Str
+=item * subscription - L<Net::Stripe::Subscription> or Str 
 
 =item * at_period_end - Bool, optional
 
@@ -665,7 +665,7 @@ Subscriptions: {
 
     # adds a subscription, keeping any existing subscriptions unmodified
     method post_subscription(Net::Stripe::Customer|Str :$customer,
-                             Net::Stripe::Subscription|Str :$subscription?,
+                             Net::Stripe::Subscription|Str :$subscription?, 
                              Net::Stripe::Plan|Str :$plan?,
                              Str :$coupon?,
                              Int|Str :$trial_end?,
@@ -693,10 +693,10 @@ Subscriptions: {
         } elsif (defined($subscription) && !ref($subscription)) {
             return $self->_post("customers/$customer/subscriptions/" . $subscription, _defined_arguments(\%args));
         }
-
+        
         return $self->_post("customers/$customer/subscriptions", _defined_arguments(\%args));
     }
-
+    
     method delete_subscription(Net::Stripe::Customer|Str :$customer,
                                Net::Stripe::Subscription|Str :$subscription,
                                Bool :$at_period_end?
@@ -720,9 +720,9 @@ Create a new token
 
 L<https://stripe.com/docs/api#create_card_token>
 
-=over
+=over 
 
-=item card - L<Net::Stripe::Card> or HashRef
+=item card - L<Net::Stripe::Card> or HashRef 
 
 =back
 
@@ -786,7 +786,7 @@ L<https://stripe.com/docs/api#create_plan>
 =back
 
 Returns a L<Net::Stripe::Plan> object
-
+ 
   $stripe->post_plan(
      id => "free-$future_ymdhms",
      amount => 0,
@@ -881,7 +881,7 @@ Plans: {
     }
 
     method get_plans(Str :$ending_before?, Int :$limit?, Str :$starting_after?) {
-        $self->_get_collections('plans',
+        $self->_get_collections('plans', 
                                 ending_before => $ending_before,
                                 limit => $limit,
                                 starting_after => $starting_after);
@@ -1010,7 +1010,7 @@ Coupons: {
     }
 
     method get_coupons(Str :$ending_before?, Int :$limit?, Str :$starting_after?) {
-        $self->_get_collections('coupons',
+        $self->_get_collections('coupons', 
                                 ending_before => $ending_before,
                                 limit => $limit,
                                 starting_after => $starting_after);
@@ -1024,7 +1024,7 @@ Update an invoice
 
 =over
 
-=item * invoice - L<Net::Stripe::Invoice>, Str
+=item * invoice - L<Net::Stripe::Invoice>, Str 
 
 =item * application_fee - Int - optional
 
@@ -1096,7 +1096,7 @@ L<https://stripe.com/docs/api#create_invoice>
 
 =over
 
-=item * customer - L<Net::Stripe::Customer>, Str
+=item * customer - L<Net::Stripe::Customer>, Str 
 
 =item * application_fee - Int - optional
 
@@ -1109,7 +1109,7 @@ L<https://stripe.com/docs/api#create_invoice>
 =back
 
 Returns a L<Net::Stripe::Invoice>
-
+  
   $stripe->create_invoice(customer => 'custid', description => 'test');
 
 =invoice_method get_invoice
@@ -1148,7 +1148,7 @@ Invoices: {
         if (ref($customer)) {
             $customer = $customer->id;
         }
-
+        
         if (ref($subscription)) {
             $subscription = $subscription->id;
         }
@@ -1194,8 +1194,8 @@ Invoices: {
 
     method get_invoices(Net::Stripe::Customer|Str :$customer?,
                         Int|HashRef :$date?,
-                        Str :$ending_before?,
-                        Int :$limit?,
+                        Str :$ending_before?, 
+                        Int :$limit?, 
                         Str :$starting_after?) {
         if (ref($customer)) {
             $customer = $customer->id
@@ -1331,7 +1331,7 @@ InvoiceItems: {
         if (ref($invoice)) {
             $invoice = $invoice->id;
         }
-
+        
         if (ref($subscription)) {
             $subscription = $subscription->id;
         }
@@ -1382,13 +1382,13 @@ InvoiceItems: {
 
     method get_invoiceitems(HashRef :$created?,
                             Net::Stripe::Customer|Str :$customer?,
-                            Str :$ending_before?,
-                            Int :$limit?,
+                            Str :$ending_before?, 
+                            Int :$limit?, 
                             Str :$starting_after?) {
         if (ref($customer)) {
             $customer = $customer->id;
         }
-        $self->_get_collections('invoiceitems',
+        $self->_get_collections('invoiceitems', 
                                 created => $created,
                                 ending_before => $ending_before,
                                 limit => $limit,
@@ -1411,7 +1411,7 @@ method _get_with_args(Str $path, $args?) {
     return $self->_get($path);
 }
 
-sub _get_collections {
+sub _get_collections { 
     my $self = shift;
     my $path = shift;
     my %args = @_;
@@ -1425,15 +1425,15 @@ sub _get_collections {
     if (my $c = $args{customer}) {
         push @path_args, "customer=$c";
     }
-
+    
     # example: $Stripe->get_charges( 'count' => 100, 'created' => { 'gte' => 1397663381 } );
     if (defined($args{created})) {
-      my %c = %{$args{created}};
+      my %c = %{$args{created}};   
       foreach my $key (keys %c) {
         if ($key =~ /(?:l|g)te?/) {
           push @path_args, "created[".$key."]=".$c{$key};
         }
-      }
+      }        
     }
     return $self->_get_with_args($path, \@path_args);
 }
@@ -1460,13 +1460,13 @@ sub convert_to_form_fields {
 }
 
 method _post(Str $path, $obj?) {
-    my $req = POST $self->api_base . '/' . $path,
+    my $req = POST $self->api_base . '/' . $path, 
         ($obj ? (Content => [ref($obj) eq 'HASH' ? %{convert_to_form_fields($obj)} : $obj->form_fields]) : ());
     return $self->_make_request($req);
 }
 
 method _make_request($req) {
-    $req->header( Authorization =>
+    $req->header( Authorization => 
         "Basic " . encode_base64($self->api_key . ':'));
 
     if ($self->debug_network) {
@@ -1525,7 +1525,7 @@ sub _hash_to_object {
 
     if (defined($hash->{object})) {
         if ($hash->{object} eq 'list') {
-            $hash->{data} = [map { _hash_to_object($_) } @{$hash->{data}}];
+            $hash->{data} = [map { _hash_to_object($_) } @{$hash->{data}}];        
             return Net::Stripe::List->new($hash);
         }
         my @words  = map { ucfirst($_) } split('_', $hash->{object});


### PR DESCRIPTION
Couple of methods were calling _post with a raw hash of args instead of a hash ref, I assume this is an old interface to _post.

Methods are:
- create_invoice
- post_invoice
- post_invoiceitem

Also some whitespace trimming from my judicious editor

Some tests in live.t were broken also, I'll create a different issue for those and look at fixing them when I get a chance.
