### PR TITLE
Implement "invoice" property on Charge objects.

### DIFF
--- a/lib/Net/Stripe/Charge.pm
+++ b/lib/Net/Stripe/Charge.pm
@@ -23,6 +23,7 @@ has 'failure_message'     => (is => 'ro', isa => 'Maybe[Str]');
 has 'failure_code'        => (is => 'ro', isa => 'Maybe[Str]');
 has 'application_fee'     => (is => 'ro', isa => 'Maybe[Int]');
 has 'metadata'            => (is => 'rw', isa => 'Maybe[HashRef]');
+has 'invoice'             => (is => 'ro', isa => 'Maybe[Str]');
 
 method form_fields {
     return (

--- a/t/live.t
+++ b/t/live.t
@@ -201,7 +201,7 @@ Charges: {
             );
         } 'Created a charge object with metadata';
         isa_ok $charge, 'Net::Stripe::Charge';
-        ok defined($charge->metadata), "charge has metadata";
+        ok defined($charge->metadata), "charge has metadata";        
         is $charge->metadata->{'hasmetadata'}, 'hello world', 'charge metadata';
         my $charge2 = $stripe->get_charge(charge_id => $charge->id);
         is $charge2->metadata->{'hasmetadata'}, 'hello world', 'charge metadata in retrieved object';
@@ -483,6 +483,10 @@ Invoices_and_items: {
         my $path = 'customers/'.$customer->id.'/cards/'.$customer->default_card;
         my $card = $stripe->_get( $path );        
         is $card->last4, $token->card->last4, 'customer has a card';
+        
+        my $ChargesList = $stripe->get_charges(limit => 1);
+        my $charge = @{$ChargesList->data}[0];
+        ok $charge->invoice, "Charge created by Subscription sign-up has an Invoice ID";
 
         my $item = $stripe->create_invoiceitem(
             customer => $customer->id,


### PR DESCRIPTION
Charge objects from Stripe have a "invoice" property which can hold an Invoice ID. The invoice ID is populated if the charge was created from an invoice, which includes any charges made as a result of subscription. 