### PR TITLE
Replace ContributorsFromGit with Git::Contributors

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,7 +13,7 @@ repo = lukec/stripe-perl
 [Git::NextVersion]
 first_version = 0.25
 [PodWeaver]
-[ContributorsFromGit]
+[Git::Contributors]
 [PkgVersion]
 [ReadmeAnyFromPod / pod.root ]
     filename = README.pod


### PR DESCRIPTION
This is because ContributorsFromGit isn't as well maintained and ETHER
created Git::Contributors out of frustration to fix this issue (see
https://github.com/RsrchBoy/Dist-Zilla-Plugin-ContributorsFromGit/issues/19).
This has the same functionality and builds and tests properly and should be
considered a better alternative.

This PR is provided in the hope that it helps.  Comments and/or questions welcome!