### PR TITLE
Ignore dzil-generated .build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Makefile
 Makefile.old
 pm_to_blib
 *.gz
+.build


### PR DESCRIPTION
This stops the automatically generated .build directory (created via dzil)
from appearing in `git status`.