### PR TITLE
Add missing ABSTRACT

### DIFF
--- a/lib/Net/Stripe/Resource.pm
+++ b/lib/Net/Stripe/Resource.pm
@@ -1,5 +1,7 @@
 package Net::Stripe::Resource;
 
+# ABSTRACT: represent a Resource object from Stripe
+
 use Moose;
 use Kavorka;
 


### PR DESCRIPTION
An ABSTRACT statement was missing in `Net::Stripe::Resource` this change adds the relevant line.  I've adapted the text from other ABSTRACTs within the project, so hopefully the text is correct for the given file.