### PR TITLE
Fix kwalitee fails

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,6 +6,7 @@ license  = Perl_5
 copyright_holder = Prime Radiant, Inc., (c) copyright 2014 Lucky Dinosaur LLC.
 copyright_year   = 2011
 [@Basic]
+[MinimumPerl]
 [AutoPrereqs]
 [@GitHub]
 repo = lukec/stripe-perl

--- a/dist.ini
+++ b/dist.ini
@@ -7,6 +7,8 @@ copyright_holder = Prime Radiant, Inc., (c) copyright 2014 Lucky Dinosaur LLC.
 copyright_year   = 2011
 [@Basic]
 [MinimumPerl]
+[MetaProvides::Class]
+[MetaProvides::Package]
 [AutoPrereqs]
 [@GitHub]
 repo = lukec/stripe-perl


### PR DESCRIPTION
There are two minor failures on the CPANTS kwalitee page for this module.  The two commits in this PR fix these issues.  It was merely necessary to define the minimum Perl version and to automatically generate the `provides` section in `META.yml`.