### PR TITLE
Update dist ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ author   = Luke Closs
 author   = Rusty Conover
 license  = Perl_5
 copyright_holder = Prime Radiant, Inc., (c) copyright 2014 Lucky Dinosaur LLC.
-copyright_year   = 2011
+copyright_year   = 2015
 [@Basic]
 [MinimumPerl]
 [MetaProvides::Class]

--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,8 @@ copyright_year   = 2015
 [MetaProvides::Class]
 [MetaProvides::Package]
 [AutoPrereqs]
+; authordep Pod::Weaver::Section::ClassMopper
+; authordep Pod::Weaver::Section::Contributors
 [@GitHub]
 repo = lukec/stripe-perl
 [ChangelogFromGit]


### PR DESCRIPTION
The major change in this PR is that the implicit dependencies within `weaver.ini` are installed as part of the `dzil authordeps --missing | cpanm` installation step.