### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: perl
+
+perl:
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+
+install:
+    - dzil authordeps --missing | cpanm --no-skip-satisfied
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied
+
+script:
+    - dzil test --author --release


### PR DESCRIPTION
This builds and tests successfully for the given Perl versions.  Perl
versions 5.12 and lower seem to have issues with installing some of the
dependencies, hence these are not tested here.