### PR TITLE
make Stripe API version settable to pass tests

### DIFF
--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -22,6 +22,7 @@ use Net::Stripe::BalanceTransaction;
 use Net::Stripe::List;
 use Net::Stripe::LineItem;
 use Net::Stripe::Refund;
+use Net::Stripe::Capture;
 
 # ABSTRACT: API client for Stripe.com
 
@@ -210,6 +211,17 @@ Charges: {
                                               amount => $amount
                                           );
         return $self->_post("charges/$charge/refunds", $refund);
+    }
+
+    method capture_charge(Net::Stripe::Charge|Str :$charge, Int :$amount?) {
+        if (ref($charge)) {
+            $charge = $charge->id;
+        }
+
+        my $capture = Net::Stripe::Capture->new(id => $charge,
+                                                amount => $amount
+                                            );
+        return $self->_post("charges/$charge/capture", $capture);
     }
 
     method get_charges(HashRef :$created?,

--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -74,11 +74,12 @@ You can set this to true to see the actual network requests.
 
 =cut
 
-has 'debug'         => (is => 'rw', isa => 'Bool',   default    => 0, documentation => "The debug flag");
-has 'debug_network' => (is => 'rw', isa => 'Bool',   default    => 0, documentation => "The debug network request flag");
-has 'api_key'       => (is => 'ro', isa => 'Str',    required   => 1, documentation => "You get this from your Stripe Account settings");
-has 'api_base'      => (is => 'ro', isa => 'Str',    lazy_build => 1, documentation => "This is the base part of the URL for every request made");
-has 'ua'            => (is => 'ro', isa => 'Object', lazy_build => 1, documentation => "The LWP::UserAgent that is used for requests");
+has 'debug'         => (is => 'rw', isa => 'Bool',   default    => 0,  documentation => "The debug flag");
+has 'debug_network' => (is => 'rw', isa => 'Bool',   default    => 0,  documentation => "The debug network request flag");
+has 'api_key'       => (is => 'ro', isa => 'Str',    required   => 1,  documentation => "You get this from your Stripe Account settings");
+has 'api_base'      => (is => 'ro', isa => 'Str',    lazy_build => 1,  documentation => "This is the base part of the URL for every request made");
+has 'ua'            => (is => 'ro', isa => 'Object', lazy_build => 1,  documentation => "The LWP::UserAgent that is used for requests");
+has 'api_version'   => (is => 'ro', isa => 'Str',    default    => '', documentation => "Set a specific API version to use");
 
 =charge_method post_charge
 
@@ -1507,6 +1508,10 @@ method _make_request($req) {
         print STDERR "Sending to Stripe:\n------\n" . $req->as_string() . "------\n";
 
     }
+    if ($self->api_version) {
+        $req->header( 'Stripe-Version' => $self->api_version );
+    }
+
     my $resp = $self->ua->request($req);
 
     if ($self->debug_network) {

--- a/lib/Net/Stripe/Capture.pm
+++ b/lib/Net/Stripe/Capture.pm
@@ -1,0 +1,38 @@
+package Net::Stripe::Capture;
+
+use Moose;
+use Kavorka;
+extends 'Net::Stripe::Resource';
+
+# ABSTRACT: represent an Charge object from Stripe
+
+has 'id'       => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'created'  => ( is => 'ro', isa => 'Maybe[Int]' );
+has 'amount'   => ( is => 'ro', isa => 'Maybe[Int]', required => 1 );
+has 'currency' => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'customer' => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'card' =>
+    ( is => 'ro', isa => 'Maybe[Net::Stripe::Token|Net::Stripe::Card|Str]' );
+has 'description'          => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'livemode'             => ( is => 'ro', isa => 'Maybe[Bool|Object]' );
+has 'paid'                 => ( is => 'ro', isa => 'Maybe[Bool|Object]' );
+has 'refunded'             => ( is => 'ro', isa => 'Maybe[Bool|Object]' );
+has 'amount_refunded'      => ( is => 'ro', isa => 'Maybe[Int]' );
+has 'captured'             => ( is => 'ro', isa => 'Maybe[Bool|Object]' );
+has 'balance_transaction'  => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'failure_message'      => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'failure_code'         => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'application_fee'      => ( is => 'ro', isa => 'Maybe[Int]' );
+has 'metadata'             => ( is => 'rw', isa => 'Maybe[HashRef]' );
+has 'invoice'              => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'receipt_email'        => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'statement_descriptor' => ( is => 'ro', isa => 'Maybe[Str]' );
+
+method form_fields {
+    return ( map { $_ => $self->$_ }
+            grep { defined $self->$_ }
+            qw/amount application_fee receipt_email statement_descriptor/ );
+}
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/Net/Stripe/Charge.pm
+++ b/lib/Net/Stripe/Charge.pm
@@ -24,11 +24,13 @@ has 'failure_code'        => (is => 'ro', isa => 'Maybe[Str]');
 has 'application_fee'     => (is => 'ro', isa => 'Maybe[Int]');
 has 'metadata'            => (is => 'rw', isa => 'Maybe[HashRef]');
 has 'invoice'             => (is => 'ro', isa => 'Maybe[Str]');
+has 'capture'             => (is => 'ro', isa => 'Maybe[Bool|Object]');
 
 method form_fields {
     return (
         $self->fields_for('card'),
         $self->form_fields_for_metadata(),
+        (defined $self->capture) ? (capture => ($self->capture) ? 'true' : 'false') : (),
         map { $_ => $self->$_ }
             grep { defined $self->$_ }
                 qw/amount currency customer description application_fee/

--- a/lib/Net/Stripe/Refund.pm
+++ b/lib/Net/Stripe/Refund.pm
@@ -15,7 +15,7 @@ has 'charge'              => (is => 'ro', isa => 'Maybe[Str]');
 has 'metadata'            => (is => 'ro', isa => 'Maybe[HashRef]');
 has 'reason'              => (is => 'ro', isa => 'Maybe[Str]');
 has 'receipt_number'      => (is => 'ro', isa => 'Maybe[Str]');
-has 'description'         => (is => 'ro', isa => 'Maybe[Str]');
+has 'status'              => (is => 'ro', isa => 'Maybe[Str]');
 
 # Create only
 has 'refund_application_fee' => (is => 'ro', isa => 'Maybe[Bool|Object]');

--- a/t/live.t
+++ b/t/live.t
@@ -188,6 +188,29 @@ Charges: {
         my $charges = $stripe->get_charges( limit => 1 );
         is scalar(@{$charges->data}), 1, 'one charge returned';
         is $charges->get(0)->id, $charge->id, 'charge ids match';
+
+        # capture a charge
+        my $charge3;
+        lives_ok {
+            $charge3 = $stripe->post_charge(
+                amount => 3300,
+                currency => 'usd',
+                card => $fake_card,
+                description => 'Wikileaks donation',
+                capture => 0
+            );
+        } 'Created a non captured-charge object';
+        ok $charge3->paid, 'charge was paid';
+        ok !$charge3->captured, 'charge was not captured';
+        my $charge4;
+        lives_ok {
+            $charge4 = $stripe->capture_charge(
+                amount => 3300,
+                charge => $charge3
+            )
+        } 'Create a capture';
+        isa_ok $charge4, 'Net::Stripe::Charge';
+        ok $charge4->captured, 'charge was captured';
     }
 
     Charge_with_metadata: {

--- a/t/live.t
+++ b/t/live.t
@@ -15,7 +15,7 @@ unless ($API_KEY) {
 
 my $future = DateTime->now + DateTime::Duration->new(years => 1);
 my $future_ymdhms = $future->ymd('-') . '-' . $future->hms('-');
-my $stripe = Net::Stripe->new(api_key => $API_KEY, debug => 1);
+my $stripe = Net::Stripe->new(api_key => $API_KEY, debug => 1, api_version => '2015-02-16');
 isa_ok $stripe, 'Net::Stripe', 'API object created today';
 
 my $fake_card = {
@@ -141,6 +141,7 @@ Charges: {
                 description => 'Wikileaks donation',
             );
         } 'Created a charge object';
+    
         isa_ok $charge, 'Net::Stripe::Charge';
         for my $field (qw/id amount created currency description
                           livemode paid refunded/) {
@@ -235,6 +236,16 @@ Charges: {
         # swallow the expected warning rather than have it print out durring tests.
         close STDERR;
         open(STDERR, ">", "/dev/null");
+
+        my $latestStripe = Net::Stripe->new(api_key => $API_KEY, debug => 1, api_version => '2015-10-16');
+        my $charge = $latestStripe->post_charge(
+            amount => 3300,
+            currency => 'usd',
+            card => $fake_card,
+            description => 'Wikileaks donation',
+        );
+        isa_ok $charge, 'Net::Stripe::Charge';
+        is $charge->card, undef, 'latest API doesn\'t know card';
 
         throws_ok {
             $stripe->post_charge(


### PR DESCRIPTION
API version is tied to the used Stripe account.
All tests pass with accounts tied to API ver. 2015-02-16 or earlier.
Accounts for later API versions make the tests fail.
Therefore i added the possibility to explicitly set the
Stripe API version. By this we make tests pass.

Next two commits enable the use of capturing charges:
- first we fix the use of param capture in post_charge
- then we add methods to enable later capturing of a charge
