### PR TITLE
Adds support for the `receipt_email` parameter on Charge objects

### DIFF
--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -106,6 +106,8 @@ L<https://stripe.com/docs/api#create_charge>
 
 =item * application_fee - Int - optional
 
+=item * receipt_email - Str - The email address to send this charge's receipt to - optional
+
 =back
 
 Returns L<Net::Stripe::Charge>
@@ -181,7 +183,8 @@ Charges: {
                        HashRef :$metadata?,
                        Bool :$capture?,
                        Str :$statement_description?,
-                       Int :$application_fee?
+                       Int :$application_fee?,
+                       Str :$receipt_email?
                      ) {
         my $charge = Net::Stripe::Charge->new(amount => $amount,
                                               currency => $currency,
@@ -191,7 +194,8 @@ Charges: {
                                               metadata => $metadata,
                                               capture => $capture,
                                               statement_description => $statement_description,
-                                              application_fee => $application_fee
+                                              application_fee => $application_fee,
+                                              receipt_email => $receipt_email
                                           );
         return $self->_post('charges', $charge);
     }

--- a/lib/Net/Stripe/Charge.pm
+++ b/lib/Net/Stripe/Charge.pm
@@ -24,6 +24,7 @@ has 'failure_code'        => (is => 'ro', isa => 'Maybe[Str]');
 has 'application_fee'     => (is => 'ro', isa => 'Maybe[Int]');
 has 'metadata'            => (is => 'rw', isa => 'Maybe[HashRef]');
 has 'invoice'             => (is => 'ro', isa => 'Maybe[Str]');
+has 'receipt_email'       => (is => 'ro', isa => 'Maybe[Str]');
 
 method form_fields {
     return (


### PR DESCRIPTION
The `receipt_email` parameter is the email address to send this
charge's receipt to. The receipt will not be sent until the charge
is paid. If this charge is for a customer, the email address
specified here will override the customer's email address.

Receipts will not be sent for test mode charges.

If `receipt_email` is specified for a charge in live mode, a receipt
will be sent regardless of your email settings.

Signed-off-by: Zach Wick zwick@stripe.com
