### PR TITLE
Support capturing charges

### DIFF
--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -23,6 +23,7 @@ use Net::Stripe::BalanceTransaction;
 use Net::Stripe::List;
 use Net::Stripe::LineItem;
 use Net::Stripe::Refund;
+use Net::Stripe::Capture;
 
 # ABSTRACT: API client for Stripe.com
 
@@ -210,6 +211,17 @@ Charges: {
                                               amount => $amount
                                           );
         return $self->_post("charges/$charge/refunds", $refund);
+    }
+
+    method capture_charge(Net::Stripe::Charge|Str :$charge, Int :$amount?) {
+        if (ref($charge)) {
+            $charge = $charge->id;
+        }
+
+        my $capture = Net::Stripe::Capture->new(id => $charge,
+                                                amount => $amount
+                                            );
+        return $self->_post("charges/$charge/capture", $capture);
     }
 
     method get_charges(HashRef :$created?,

--- a/lib/Net/Stripe/Capture.pm
+++ b/lib/Net/Stripe/Capture.pm
@@ -1,0 +1,38 @@
+package Net::Stripe::Capture;
+
+use Moose;
+use Kavorka;
+extends 'Net::Stripe::Resource';
+
+# ABSTRACT: represent an Charge object from Stripe
+
+has 'id'       => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'created'  => ( is => 'ro', isa => 'Maybe[Int]' );
+has 'amount'   => ( is => 'ro', isa => 'Maybe[Int]', required => 1 );
+has 'currency' => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'customer' => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'card' =>
+    ( is => 'ro', isa => 'Maybe[Net::Stripe::Token|Net::Stripe::Card|Str]' );
+has 'description'          => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'livemode'             => ( is => 'ro', isa => 'Maybe[Bool|Object]' );
+has 'paid'                 => ( is => 'ro', isa => 'Maybe[Bool|Object]' );
+has 'refunded'             => ( is => 'ro', isa => 'Maybe[Bool|Object]' );
+has 'amount_refunded'      => ( is => 'ro', isa => 'Maybe[Int]' );
+has 'captured'             => ( is => 'ro', isa => 'Maybe[Bool|Object]' );
+has 'balance_transaction'  => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'failure_message'      => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'failure_code'         => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'application_fee'      => ( is => 'ro', isa => 'Maybe[Int]' );
+has 'metadata'             => ( is => 'rw', isa => 'Maybe[HashRef]' );
+has 'invoice'              => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'receipt_email'        => ( is => 'ro', isa => 'Maybe[Str]' );
+has 'statement_descriptor' => ( is => 'ro', isa => 'Maybe[Str]' );
+
+method form_fields {
+    return ( map { $_ => $self->$_ }
+            grep { defined $self->$_ }
+            qw/amount application_fee receipt_email statement_descriptor/ );
+}
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/Net/Stripe/Capture.pm
+++ b/lib/Net/Stripe/Capture.pm
@@ -4,7 +4,7 @@ use Moose;
 use Kavorka;
 extends 'Net::Stripe::Resource';
 
-# ABSTRACT: represent an Charge object from Stripe
+# ABSTRACT: represent a Capture object from Stripe
 
 has 'id'       => ( is => 'ro', isa => 'Maybe[Str]' );
 has 'created'  => ( is => 'ro', isa => 'Maybe[Int]' );

--- a/lib/Net/Stripe/Charge.pm
+++ b/lib/Net/Stripe/Charge.pm
@@ -24,11 +24,13 @@ has 'failure_code'        => (is => 'ro', isa => 'Maybe[Str]');
 has 'application_fee'     => (is => 'ro', isa => 'Maybe[Int]');
 has 'metadata'            => (is => 'rw', isa => 'Maybe[HashRef]');
 has 'invoice'             => (is => 'ro', isa => 'Maybe[Str]');
+has 'capture'             => (is => 'ro', isa => 'Maybe[Bool|Object]');
 
 method form_fields {
     return (
         $self->fields_for('card'),
         $self->form_fields_for_metadata(),
+        (defined $self->capture) ? (capture => ($self->capture) ? 'true' : 'false') : (),
         map { $_ => $self->$_ }
             grep { defined $self->$_ }
                 qw/amount currency customer description application_fee/

--- a/t/live.t
+++ b/t/live.t
@@ -187,6 +187,29 @@ Charges: {
         my $charges = $stripe->get_charges( limit => 1 );
         is scalar(@{$charges->data}), 1, 'one charge returned';
         is $charges->get(0)->id, $charge->id, 'charge ids match';
+
+        # capture a charge
+        my $charge3;
+        lives_ok {
+            $charge3 = $stripe->post_charge(
+                amount => 3300,
+                currency => 'usd',
+                card => $fake_card,
+                description => 'Wikileaks donation',
+                capture => 0
+            );
+        } 'Created a non captured-charge object';
+        ok $charge3->paid, 'charge was paid';
+        ok !$charge3->captured, 'charge was not captured';
+        my $charge4;
+        lives_ok {
+            $charge4 = $stripe->capture_charge(
+                amount => 3300,
+                charge => $charge3
+            )
+        } 'Create a capture';
+        isa_ok $charge4, 'Net::Stripe::Charge';
+        ok $charge4->captured, 'charge was captured';
     }
 
     Charge_with_metadata: {


### PR DESCRIPTION
Hello Andrew,

this PR adds support for the so called two-step payment flow, where first you created a charge with the capture option set to false. Second step is to capture the payment of an existing, uncaptured, charge.

See https://stripe.com/docs/api#capture_charge for reference.

Best regards,
Florian