### PR TITLE
[WIP] Add explicit control over the API version

### DIFF
--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -91,6 +91,7 @@ has 'debug_network' => (is => 'rw', isa => 'Bool',   default    => 0, documentat
 has 'api_key'       => (is => 'ro', isa => 'Str',    required   => 1, documentation => "You get this from your Stripe Account settings");
 has 'api_base'      => (is => 'ro', isa => 'Str',    lazy_build => 1, documentation => "This is the base part of the URL for every request made");
 has 'ua'            => (is => 'ro', isa => 'Object', lazy_build => 1, documentation => "The LWP::UserAgent that is used for requests");
+has 'api_version'   => (is => 'ro', isa => 'Str',    default    => '', documentation => "This is the value of the Stripe-Version header you wish to use for API calls");
 
 =charge_method post_charge
 
@@ -1548,6 +1549,10 @@ method _post(Str $path, $obj?) {
 method _make_request($req) {
     $req->header( Authorization =>
         "Basic " . encode_base64($self->api_key . ':'));
+
+    if ($self->api_version) {
+         $req->header( 'Stripe-Version' => $self->api_version );
+    }
 
     if ($self->debug_network) {
         print STDERR "Sending to Stripe:\n------\n" . $req->as_string() . "------\n";

--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -8,6 +8,7 @@ use HTTP::Request::Common qw/GET POST DELETE/;
 use MIME::Base64 qw/encode_base64/;
 use URI::Escape qw/uri_escape/;
 use JSON qw/decode_json/;
+use Net::Stripe::TypeConstraints;
 use Net::Stripe::Token;
 use Net::Stripe::Invoiceitem;
 use Net::Stripe::Invoice;
@@ -91,7 +92,7 @@ has 'debug_network' => (is => 'rw', isa => 'Bool',   default    => 0, documentat
 has 'api_key'       => (is => 'ro', isa => 'Str',    required   => 1, documentation => "You get this from your Stripe Account settings");
 has 'api_base'      => (is => 'ro', isa => 'Str',    lazy_build => 1, documentation => "This is the base part of the URL for every request made");
 has 'ua'            => (is => 'ro', isa => 'Object', lazy_build => 1, documentation => "The LWP::UserAgent that is used for requests");
-has 'api_version'   => (is => 'ro', isa => 'Str',    default    => '', documentation => "This is the value of the Stripe-Version header you wish to use for API calls");
+has 'api_version'   => (is => 'ro', isa => 'Net::Stripe::Types::api_version', documentation => "This is the value of the Stripe-Version header you wish to use for API calls");
 
 =charge_method post_charge
 

--- a/lib/Net/Stripe/TypeConstraints.pm
+++ b/lib/Net/Stripe/TypeConstraints.pm
@@ -1,15 +1,32 @@
 package Net::Stripe::TypeConstraints;
 
 use strict;
-use Moose::Util::TypeConstraints;
+use Moose::Util::TypeConstraints qw(subtype as where message);
+use DateTime qw();
 
 subtype 'Net::Stripe::Types::api_version',
     as 'Str',
-    where { Net::Stripe::TypeConstraints::m_api_version( $_ ) },
-    message { "api_version expects yyyy-mm-dd: '$_'" };
-
-sub m_api_version {
-    return /^\d{4}-\d{2}-\d{2}$/;
-}
+    where {
+        my $min = '2012-10-26';
+        my $max = DateTime->now->ymd('-');
+        return if $_ !~ /^\d{4}-\d{2}-\d{2}$/;
+        return if $_ lt $min;
+        return if $_ gt $max;
+        return 1;
+    },
+    message {
+        my $min = '2012-10-26';
+        my $max = DateTime->now->ymd('-');
+        if ($_ !~ /^\d{4}-\d{2}-\d{2}$/) {
+            return sprintf("value '%s' must be a Stripe API version string of the form yyyy-mm-dd", $_);
+        } elsif ($_ lt $min) {
+            return sprintf("value '%s' must be %s or after", $_, $min);
+        } elsif ($_ gt $max) {
+            return sprintf("value '%s' must be %s or before", $_, $max);
+        } else {
+            # how do we get here? just in case :-)
+            return sprintf("invalid Stripe API version: '%s'", $_);
+        }
+    };
 
 1;

--- a/lib/Net/Stripe/TypeConstraints.pm
+++ b/lib/Net/Stripe/TypeConstraints.pm
@@ -1,0 +1,15 @@
+package Net::Stripe::TypeConstraints;
+
+use strict;
+use Moose::Util::TypeConstraints;
+
+subtype 'Net::Stripe::Types::api_version',
+    as 'Str',
+    where { Net::Stripe::TypeConstraints::m_api_version( $_ ) },
+    message { "api_version expects yyyy-mm-dd: '$_'" };
+
+sub m_api_version {
+    return /^\d{4}-\d{2}-\d{2}$/;
+}
+
+1;

--- a/t/live.t
+++ b/t/live.t
@@ -31,6 +31,16 @@ unless ($API_KEY =~ m/^sk_test_/) {
     );
     isa_ok $stripe, 'Net::Stripe', qq[API object created with explicit API version: "$api_version"];
     is $stripe->api_version(), $api_version, 'stripe object api_version';
+
+    foreach my $api_version (qw/notanapiversionstring 20150216 2015-2-16/) {
+        throws_ok {
+            $stripe = Net::Stripe->new(
+                api_key     => $API_KEY,
+                api_version => $api_version,
+                debug       => 1,
+            );
+        } qr/api_version expects yyyy-mm-dd/, 'invalid api_version format';
+    }
 }
 
 my $future = DateTime->now + DateTime::Duration->new(years => 1);

--- a/t/live.t
+++ b/t/live.t
@@ -34,7 +34,7 @@ unless ($API_KEY =~ m/^sk_test_/) {
 
     foreach my $api_version (qw/notanapiversionstring 20150216 2015-2-16/) {
         throws_ok {
-            $stripe = Net::Stripe->new(
+            Net::Stripe->new(
                 api_key     => $API_KEY,
                 api_version => $api_version,
                 debug       => 1,
@@ -43,7 +43,7 @@ unless ($API_KEY =~ m/^sk_test_/) {
     }
 
     throws_ok {
-        $stripe = Net::Stripe->new(
+        Net::Stripe->new(
             api_key     => $API_KEY,
             api_version => '2012-09-24',
             debug       => 1,
@@ -52,7 +52,7 @@ unless ($API_KEY =~ m/^sk_test_/) {
 
     throws_ok {
         my $tomorrow = (DateTime->now + DateTime::Duration->new(days => 1))->ymd('-');
-        $stripe = Net::Stripe->new(
+        Net::Stripe->new(
             api_key     => $API_KEY,
             api_version => $tomorrow,
             debug       => 1,

--- a/t/live.t
+++ b/t/live.t
@@ -19,6 +19,19 @@ unless ($API_KEY =~ m/^sk_test_/) {
     exit;
 }
 
+{
+    # is there a reliable method to determine that a given object is
+    # passing the correct API version to stripe, and that the value is
+    # being respected by the API?
+    my $api_version = '2017-08-15';
+    my $stripe = Net::Stripe->new(
+        api_key     => $API_KEY,
+        api_version => $api_version,
+        debug       => 1,
+    );
+    isa_ok $stripe, 'Net::Stripe', qq[API object created with explicit API version: "$api_version"];
+    is $stripe->api_version(), $api_version, 'stripe object api_version';
+}
 
 my $future = DateTime->now + DateTime::Duration->new(years => 1);
 my $future_ymdhms = $future->ymd('-') . '-' . $future->hms('-');

--- a/t/live.t
+++ b/t/live.t
@@ -39,8 +39,25 @@ unless ($API_KEY =~ m/^sk_test_/) {
                 api_version => $api_version,
                 debug       => 1,
             );
-        } qr/api_version expects yyyy-mm-dd/, 'invalid api_version format';
+        } qr/of the form yyyy-mm-dd/, 'invalid api_version format';
     }
+
+    throws_ok {
+        $stripe = Net::Stripe->new(
+            api_key     => $API_KEY,
+            api_version => '2012-09-24',
+            debug       => 1,
+        );
+    } qr/must be .+ or after/, 'min api_version';
+
+    throws_ok {
+        my $tomorrow = (DateTime->now + DateTime::Duration->new(days => 1))->ymd('-');
+        $stripe = Net::Stripe->new(
+            api_key     => $API_KEY,
+            api_version => $tomorrow,
+            debug       => 1,
+        );
+    } qr/must be .+ or before/, 'max api_version';
 }
 
 my $future = DateTime->now + DateTime::Duration->new(years => 1);


### PR DESCRIPTION
Add explicit control over the API version https://stripe.com/docs/api#versioning via api_version when creating a new Net::Stripe object.

Set api_version in test scripts via $ENV{STRIPE_API_VERSION} in order to allow for:
  STRIPE_API_VERSION="2015-02-16" prove -olv t/live.t
  STRIPE_API_VERSION="2017-08-15" prove -olv t/live.t
  etc