### PR TITLE
replace _get() with get_card in unit tests

### DIFF
--- a/t/live.t
+++ b/t/live.t
@@ -336,8 +336,10 @@ Customers: {
                 description => 'Test for Net::Stripe',
                 metadata => {'somemetadata' => 'hello world'},
             );
-            my $path = 'customers/'.$customer->id.'/cards/'.$customer->default_card;
-            my $card = $stripe->_get( $path );
+            my $card = $stripe->get_card(
+                customer=> $customer,
+                card_id=> $customer->default_card,
+            );
             isa_ok $card, 'Net::Stripe::Card';
             is $card->country, 'US', 'card country';
             is $card->exp_month, $future->month, 'card exp_month';
@@ -354,8 +356,10 @@ Customers: {
             );
             isa_ok $customer, 'Net::Stripe::Customer', 'got back a customer';
             ok $customer->id, 'customer has an id';
-            my $path = 'customers/'.$customer->id.'/cards/'.$customer->default_card;
-            my $card = $stripe->_get( $path );
+            my $card = $stripe->get_card(
+                customer=> $customer,
+                card_id=> $customer->default_card,
+            );
             is $card->last4, '4242', 'card token ok';
         }
 
@@ -492,8 +496,10 @@ Invoices_and_items: {
         );
         ok $customer->id, 'customer has an id';
         is $customer->subscription->plan->id, $plan->id, 'customer has a plan';
-        my $path = 'customers/'.$customer->id.'/cards/'.$customer->default_card;
-        my $card = $stripe->_get( $path );
+            my $card = $stripe->get_card(
+                customer=> $customer,
+                card_id=> $customer->default_card,
+            );
         is $card->last4, $token->card->last4, 'customer has a card';
         
         my $ChargesList = $stripe->get_charges(limit => 1);


### PR DESCRIPTION
instead of manually constructing paths and calling _get() directly, use the more-robust get_card()