### PR TITLE
avoid objectification for deleted objects

### DIFF
--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -1571,6 +1571,10 @@ sub _defined_arguments {
 sub _hash_to_object {
     my $hash   = shift;
 
+    if ( exists( $hash->{deleted} ) && exists( $hash->{object} ) && $hash->{object} ne 'customer' ) {
+      delete( $hash->{object} );
+    }
+
     foreach my $k (grep { ref($hash->{$_}) } keys %$hash) {
         my $v = $hash->{$k};
         if (ref($v) eq 'HASH' && defined($v->{object})) {


### PR DESCRIPTION
stripe now seems to be passing back the object type for deleted objects. when
we objectify them in _hash_to_object() the deleted field is dropped since most
objects do not define that field explicitly. by manually deleteing the object
type from the returned hash, we can follow the previous code path.