### PR TITLE
update statement_description to statement_descriptor

### DIFF
--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -68,6 +68,18 @@ where discussion on these topics takes place.
 
 =head2 Version 0.40
 
+=over
+
+=item update statement_description to statement_descriptor
+
+The statement_description attribute is now statement_descriptor for
+L<Net::Stripe::Charge> and L<Net::Stripe::Plan>. The API docs
+L<https://stripe.com/docs/upgrades#2014-12-17> indicate that this change
+is backwards-compatible. You must update your code to reflect this change
+for parameters passed to these objects and methods called on these objects.
+
+=back
+
 =method new PARAMHASH
 
 This creates a new stripe API object.  The following parameters are accepted:
@@ -118,7 +130,7 @@ L<https://stripe.com/docs/api#create_charge>
 
 =item * capture - Bool - optional
 
-=item * statement_description - Str - description for statement - optional
+=item * statement_descriptor - Str - descriptor for statement - optional
 
 =item * application_fee - Int - optional
 
@@ -198,7 +210,7 @@ Charges: {
                        Str :$description?,
                        HashRef :$metadata?,
                        Bool :$capture?,
-                       Str :$statement_description?,
+                       Str :$statement_descriptor?,
                        Int :$application_fee?,
                        Str :$receipt_email?
                      ) {
@@ -209,7 +221,7 @@ Charges: {
                                               description => $description,
                                               metadata => $metadata,
                                               capture => $capture,
-                                              statement_description => $statement_description,
+                                              statement_descriptor => $statement_descriptor,
                                               application_fee => $application_fee,
                                               receipt_email => $receipt_email
                                           );
@@ -822,7 +834,7 @@ L<https://stripe.com/docs/api#create_plan>
 
 =item * trial_period_days - Int - optional
 
-=item * statement_description - Str - optional
+=item * statement_descriptor - Str - optional
 
 =back
 
@@ -897,7 +909,7 @@ Plans: {
                      Str :$name,
                      Int :$trial_period_days?,
                      HashRef :$metadata?,
-                     Str :$statement_description?) {
+                     Str :$statement_descriptor?) {
         my $plan = Net::Stripe::Plan->new(id => $id,
                                           amount => $amount,
                                           currency => $currency,
@@ -906,7 +918,7 @@ Plans: {
                                           name => $name,
                                           trial_period_days => $trial_period_days,
                                           metadata => $metadata,
-                                          statement_description => $statement_description);
+                                          statement_descriptor => $statement_descriptor);
         return $self->_post('plans', $plan);
     }
 

--- a/lib/Net/Stripe/Charge.pm
+++ b/lib/Net/Stripe/Charge.pm
@@ -27,6 +27,7 @@ has 'invoice'             => (is => 'ro', isa => 'Maybe[Str]');
 has 'receipt_email'       => (is => 'ro', isa => 'Maybe[Str]');
 has 'status'              => (is => 'ro', isa => 'Maybe[Str]');
 has 'capture'             => (is => 'ro', isa => 'Bool', default=> 1);
+has 'statement_descriptor' => (is => 'ro', isa => 'Maybe[Str]');
 
 method form_fields {
     return (
@@ -34,7 +35,8 @@ method form_fields {
         $self->form_fields_for_metadata(),
         map { $_ => $self->get_form_field_value( $_ ) }
             grep { defined $self->$_ }
-                qw/amount currency customer description application_fee receipt_email capture/
+                qw/amount currency customer description application_fee receipt_email capture
+                   statement_descriptor/
     );
 }
 

--- a/lib/Net/Stripe/Plan.pm
+++ b/lib/Net/Stripe/Plan.pm
@@ -7,10 +7,10 @@ extends 'Net::Stripe::Resource';
 
 # ABSTRACT: represent a Plan object from Stripe
 
-subtype 'StatementDescription',
+subtype 'StatementDescriptor',
     as 'Str',
     where { !defined($_) || $_ =~ /^[^<>"']{0,15}$/ },
-    message { "The statement description you provided '$_' must be 15 characters or less and not contain <>\"'." };
+    message { "The statement descriptor you provided '$_' must be 15 characters or less and not contain <>\"'." };
 
 has 'id'                => (is => 'ro', isa => 'Maybe[Str]', required => 1);
 has 'amount'            => (is => 'ro', isa => 'Maybe[Int]', required => 1);
@@ -19,13 +19,13 @@ has 'interval'          => (is => 'ro', isa => 'Maybe[Str]', required => 1);
 has 'interval_count'    => (is => 'ro', isa => 'Maybe[Int]', required => 0);
 has 'name'              => (is => 'ro', isa => 'Maybe[Str]', required => 1);
 has 'trial_period_days' => (is => 'ro', isa => 'Maybe[Int]');
-has 'statement_description' => ('is' => 'ro', isa => 'Maybe[StatementDescription]', required => 0);
+has 'statement_descriptor' => (is => 'ro', isa => 'Maybe[StatementDescriptor]', required => 0);
 
 method form_fields {
     return (
         map { $_ => $self->$_ }
             grep { defined $self->$_ }
-                qw/id amount currency interval interval_count name statement_description trial_period_days/
+                qw/id amount currency interval interval_count name statement_descriptor trial_period_days/
     );
 }
 

--- a/t/live.t
+++ b/t/live.t
@@ -78,9 +78,11 @@ Plans: {
             interval => 'month',
             name => "Test Plan - $future",
             trial_period_days => 10,
+            statement_descriptor => 'Statement Descr',
         );
         isa_ok $plan, 'Net::Stripe::Plan',
             'I love it when a plan comes together';
+        is $plan->statement_descriptor, 'Statement Descr', 'plan statement_descriptor matches';
 
         my $newplan = $stripe->get_plan(plan_id => $id);
         isa_ok $newplan, 'Net::Stripe::Plan',
@@ -154,17 +156,19 @@ Charges: {
                 currency => 'usd',
                 card => $fake_card,
                 description => 'Wikileaks donation',
+                statement_descriptor => 'Statement Descr',
             );
         } 'Created a charge object';
         isa_ok $charge, 'Net::Stripe::Charge';
         for my $field (qw/id amount created currency description
-                          livemode paid refunded status/) {
+                          livemode paid refunded status statement_descriptor/) {
             ok defined($charge->$field), "charge has $field";
         }
         ok !$charge->refunded, 'charge is not refunded';
         ok $charge->paid, 'charge was paid';
         is $charge->status, 'paid', 'charge status is paid';
         ok $charge->captured, 'charge was captured';
+        is $charge->statement_descriptor, 'Statement Descr', 'charge statement_descriptor matches';
 
         # Check out the returned card object
         my $card = $charge->card;


### PR DESCRIPTION
update statement_description to backwards-compatible statement_descriptor for Net::Stripe::Charge and Net::Stripe::Plan <https://stripe.com/docs/upgrades#2014-12-17>;
add failing test to detect previously-missing attribute in Net::Stripe::Charge;

my testing, and the [documentation](https://stripe.com/docs/upgrades#2014-12-17
) shows this change to be backwards-compatible:
"If not on this API version or newer, providing a statement_descriptor still triggers the statement_description behavior."

we were previously passing statement_description to `Net::Stripe::Charge`, but it was being dropped on the floor since there was no matching attribute.