### PR TITLE
fix POD oversights

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -68,6 +68,54 @@ You can set this to true to see the actual network requests.
 
 =back
 
+=head1 ATTRIBUTES
+
+=head2 api_base
+
+Reader: api_base
+
+Type: Str
+
+Additional documentation: This is the base part of the URL for every request made
+
+=head2 api_key
+
+Reader: api_key
+
+Type: Str
+
+This attribute is required.
+
+Additional documentation: You get this from your Stripe Account settings
+
+=head2 debug
+
+Reader: debug
+
+Writer: debug
+
+Type: Bool
+
+Additional documentation: The debug flag
+
+=head2 debug_network
+
+Reader: debug_network
+
+Writer: debug_network
+
+Type: Bool
+
+Additional documentation: The debug network request flag
+
+=head2 ua
+
+Reader: ua
+
+Type: Object
+
+Additional documentation: The LWP::UserAgent that is used for requests
+
 =head1 Balance Transaction Methods
 
 =head2 get_balance_transaction
@@ -452,7 +500,7 @@ L<https://stripe.com/docs/api#create_card_token>
 
 =over
 
-=item card - L<Net::Stripe::Card> or HashRef
+=item * card - L<Net::Stripe::Card> or HashRef
 
 =back
 
@@ -872,7 +920,9 @@ Returns a L<Net::Stripe::List> object containing L<Net::Stripe::Invoiceitem> obj
 
   $stripe->get_invoiceitems(customer => 'test', limit => 30);
 
-=discount_method delete_customer_discount
+=head1 Discount Methods
+
+=head2 delete_customer_discount
 
 Deletes a customer-wide discount.
 
@@ -895,6 +945,8 @@ Returns hashref of the form
 =head1 SEE ALSO
 
 L<https://stripe.com>, L<https://stripe.com/docs/api>
+
+=encoding UTF-8
 
 =head1 AUTHORS
 
@@ -955,6 +1007,10 @@ Hermann Calabria <hermann@ivouch.com>
 =item *
 
 Jonathan "Duke" Leto <jonathan@leto.net>
+
+=item *
+
+Luke Closs <lukec@users.noreply.github.com>
 
 =item *
 

--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,7 @@ abstract = API client for Stripe.com
 author   = Luke Closs
 author   = Rusty Conover
 license  = Perl_5
-copyright_holder = Prime Radiant, Inc., (c) copyright 2014 Lucky Dinosaur LLC.
+copyright_holder = Prime Radiant, Inc., (c) copyright 2014 Lucky Dinosaur LLC
 copyright_year   = 2015
 [@Basic]
 [MinimumPerl]

--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -759,7 +759,7 @@ L<https://stripe.com/docs/api#create_card_token>
 
 =over
 
-=item card - L<Net::Stripe::Card> or HashRef
+=item * card - L<Net::Stripe::Card> or HashRef
 
 =back
 
@@ -1633,6 +1633,8 @@ method _build_ua {
 =head1 SEE ALSO
 
 L<https://stripe.com>, L<https://stripe.com/docs/api>
+
+=encoding UTF-8
 
 =cut
 

--- a/weaver.ini
+++ b/weaver.ini
@@ -45,6 +45,8 @@ command = invoice_method
 [Collect / Invoice Item Methods]
 command = invoiceitem_method
 
+[Collect / Discount Methods]
+command = discount_method
 
 [Leftovers]
 [Region  / postlude]


### PR DESCRIPTION
update POD, dist.ini and weaver.ini:
 * add encoding declaration to POD to fix unsafe character warning. this was fixed directly in README.pod during a previous commit, but was overwritten during the dzil regeneration of README.pod.
 * add missing section for Discount methods in weaver.ini
 * remove trailing period from copyright_holder in dist.ini. apparently dzil adds a period when regenerating README.pod.
 * regenerate README.pod