### PR TITLE
remove redundant Token tests

### DIFF
--- a/t/live.t
+++ b/t/live.t
@@ -58,12 +58,6 @@ Card_Tokens: {
         my $same = $stripe->get_token(token_id => $token->id);
         isa_ok $token, 'Net::Stripe::Token', 'got a token back';
         is $same->id, $token->id, 'token id matches';
-
-
-        my $no_amount = $stripe->post_token( card => $fake_card );
-        isa_ok $no_amount, 'Net::Stripe::Token', 'got a token back';
-        is $no_amount->card->last4, '4242', 'token card';
-        ok !$no_amount->used, 'token is not used';
     }
 }
 


### PR DESCRIPTION
The tests on `$no_amount` became redundant when the Token tests were
reworked in `8ca8bcc` to remove `amount` and `currency`, and should
have been removed at that time. Closes <https://github.com/lukec/stripe-perl/issues/126>.