### PR TITLE
_defined_arguments() is unnecessary

### DIFF
--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -449,7 +449,7 @@ Customers: {
                 metadata => $metadata,
             );
 
-            return $self->_post("customers/" . $customer, _defined_arguments(\%args));
+            return $self->_post("customers/" . $customer, \%args);
         }
 
 
@@ -1626,13 +1626,6 @@ method _make_request($req) {
 
     warn "$e\n" if $self->debug;
     die $e;
-}
-
-sub _defined_arguments {
-    my $args = shift;
-
-    map { delete $args->{$_} } grep {  !defined($args->{$_}) } keys %$args;
-    return $args;
 }
 
 sub _hash_to_object {


### PR DESCRIPTION
 * only called in post_customer() for hashref argument to _post()
 * _post() calls convert_to_form_fields() for hashrefs
 * convert_to_form_fields() skips hashref keys with undefined values
 * closes <https://github.com/lukec/stripe-perl/issues/136>