### PR TITLE
fix post_customer() arguments

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -252,11 +252,11 @@ L<https://stripe.com/docs/api#create_customer>
 
 =over
 
-=item * customer - L<Net::Stripe::Customer> - existing customer to update, optional
+=item * customer - L<Net::Stripe::Customer> or StripeCustomerId - existing customer to update, optional
 
 =item * account_balance - Int, optional
 
-=item * card - L<Net::Stripe::Card>, L<Net::Stripe::Token>, Str or HashRef, default card for the customer, optional
+=item * card - L<Net::Stripe::Token>, StripeTokenId or HashRef, default card for the customer, optional
 
 =item * coupon - Str, optional
 
@@ -1046,6 +1046,16 @@ L<https://github.com/lukec/stripe-perl/issues/100>. We removed the dead code
 paths and made the conditional structure more explicit, per discussion in
 <https://github.com/lukec/stripe-perl/pull/133>. We also added unit tests
 for all calling forms, per <https://github.com/lukec/stripe-perl/issues/139>.
+
+=item fix post_customer() arguments
+
+Some argument types for `card` are not legitimate and have been removed from
+the Kavorka method signature. We removed `Net::Stripe::Card` and updated the
+string validation to disallow card id for `card`, as neither of these are
+legitimate when creating or updating a customer L<https://github.com/lukec/stripe-perl/issues/138>.
+We have also updated the structure of the method so that we always create a
+Net::Stripe::Customer object before posting L<https://github.com/lukec/stripe-perl/issues/148>
+and cleaned up and centralized Net::Stripe:Token coercion code.
 
 =back
 

--- a/lib/Net/Stripe/Customer.pm
+++ b/lib/Net/Stripe/Customer.pm
@@ -15,7 +15,7 @@ extends 'Net::Stripe::Resource';
 has 'email'       => (is => 'rw', isa => 'Maybe[Str]');
 has 'description' => (is => 'rw', isa => 'Maybe[Str]');
 has 'trial_end'   => (is => 'rw', isa => 'Maybe[Int|Str]');
-has 'card'        => (is => 'rw', isa => 'Maybe[Net::Stripe::Token|Net::Stripe::Card|Str]');
+has 'card'        => (is => 'rw', isa => 'Maybe[Net::Stripe::Token|Net::Stripe::Card|StripeTokenId]');
 has 'quantity'    => (is => 'rw', isa => 'Maybe[Int]');
 has 'plan'        => (is => 'rw', isa => 'Maybe[Net::Stripe::Plan|Str]');
 has 'coupon'      => (is => 'rw', isa => 'Maybe[Net::Stripe::Coupon|Str]');
@@ -41,8 +41,7 @@ sub _build_subscription {
 
 method form_fields {
     return (
-        (($self->card && ref($self->card) eq 'Net::Stripe::Token') ?
-            (card => $self->card->id) : $self->fields_for('card')),
+        $self->fields_for('card'),
         $self->fields_for('plan'),
         $self->fields_for('coupon'),
         $self->form_fields_for_metadata(),

--- a/lib/Net/Stripe/Resource.pm
+++ b/lib/Net/Stripe/Resource.pm
@@ -72,6 +72,7 @@ method fields_for($for) {
     return unless $self->can($for);
     my $thingy = $self->$for;
     return unless $thingy;
+    return ($for => $thingy->id) if $for eq 'card' && ref($thingy) eq 'Net::Stripe::Token';
     return $thingy->form_fields if ref($thingy) =~ m/^Net::Stripe::/;
     return ($for => $thingy);
 }


### PR DESCRIPTION
 * updated Kavorka signature to remove non-functional or illegitimate argument types
 * removed Net::Stripe::Card and disallowed card id for card, as neither form is valid conceptually <https://github.com/lukec/stripe-perl/issues/138>
 * always create a Net::Stripe::Customer object before _post() to take advantage of argument coercion during objectification <https://github.com/lukec/stripe-perl/issues/148>
 * include omitted arguments in object creation
 * clean up and centralize Net::Stripe:Token coercion code, since we always need the token id
 * added unit tests to exercise all allowed argument forms for customer creation and customer update <https://github.com/lukec/stripe-perl/issues/139>
 * closes <https://github.com/lukec/stripe-perl/issues/138>