### PR TITLE
update unit tests for Charge->status

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -1057,6 +1057,16 @@ We have also updated the structure of the method so that we always create a
 Net::Stripe::Customer object before posting L<https://github.com/lukec/stripe-perl/issues/148>
 and cleaned up and centralized Net::Stripe:Token coercion code.
 
+=item update unit tests for Charge->status
+
+For Stripe API versions after 2015-02-18 L<https://stripe.com/docs/upgrades#2015-02-18>,
+the status property on the Charge object has a value of 'succeeded' for
+successful charges. Previously, the status property would be 'paid' for
+successful charges. This change does not affect the API calls themselves, but
+if your account is using Stripe API version 2015-02-18 or later, you should
+update any code that relies on strict checking of the return value of
+Charge->status.
+
 =back
 
 =head1 SEE ALSO

--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -137,6 +137,16 @@ We have also updated the structure of the method so that we always create a
 Net::Stripe::Customer object before posting L<https://github.com/lukec/stripe-perl/issues/148>
 and cleaned up and centralized Net::Stripe:Token coercion code.
 
+=item update unit tests for Charge->status
+
+For Stripe API versions after 2015-02-18 L<https://stripe.com/docs/upgrades#2015-02-18>,
+the status property on the Charge object has a value of 'succeeded' for
+successful charges. Previously, the status property would be 'paid' for
+successful charges. This change does not affect the API calls themselves, but
+if your account is using Stripe API version 2015-02-18 or later, you should
+update any code that relies on strict checking of the return value of
+Charge->status.
+
 =back
 
 =method new PARAMHASH

--- a/t/live.t
+++ b/t/live.t
@@ -160,7 +160,7 @@ Charges: {
         }
         ok !$charge->refunded, 'charge is not refunded';
         ok $charge->paid, 'charge was paid';
-        is $charge->status, 'paid', 'charge status is paid';
+        like $charge->status, qr/^(?:paid|succeeded)$/, 'charge was successful';
         ok $charge->captured, 'charge was captured';
         is $charge->statement_descriptor, 'Statement Descr', 'charge statement_descriptor matches';
 
@@ -258,7 +258,7 @@ Charges: {
         );
         isa_ok $charge, 'Net::Stripe::Charge';
         ok $charge->paid, 'charge was paid';
-        is $charge->status, 'paid', 'charge status is paid';
+        like $charge->status, qr/^(?:paid|succeeded)$/, 'charge was successful';
 
         my $cards = $stripe->get_cards(customer => $customer, limit => 1);
         isa_ok $cards, "Net::Stripe::List";
@@ -276,7 +276,7 @@ Charges: {
         );
         isa_ok $charge, 'Net::Stripe::Charge';
         ok $charge->paid, 'charge was paid';
-        is $charge->status, 'paid', 'charge status is paid';
+        like $charge->status, qr/^(?:paid|succeeded)$/, 'charge was successful';
         is $charge->card->id, $token->card->id, 'charge card id matches';
     }
 
@@ -307,7 +307,7 @@ Charges: {
         );
         isa_ok $charge, 'Net::Stripe::Charge';
         ok $charge->paid, 'charge was paid';
-        is $charge->status, 'paid', 'charge status is paid';
+        like $charge->status, qr/^(?:paid|succeeded)$/, 'charge was successful';
         is $charge->card->last4, substr( $fake_card->{number}, -4 ), 'charge card last4 matches';
     }
 
@@ -322,7 +322,7 @@ Charges: {
         );
         isa_ok $charge, 'Net::Stripe::Charge';
         ok $charge->paid, 'charge was paid';
-        is $charge->status, 'paid', 'charge status is paid';
+        like $charge->status, qr/^(?:paid|succeeded)$/, 'charge was successful';
         is $charge->card->id, $customer->default_card, 'charged default card';
     }
 
@@ -391,7 +391,7 @@ Charges: {
         );
         isa_ok $charge, 'Net::Stripe::Charge';
         ok $charge->paid, 'charge was paid';
-        is $charge->status, 'paid', 'charge status is paid';
+        like $charge->status, qr/^(?:paid|succeeded)$/, 'charge was successful';
         is $charge->card->id, $card->id, 'charge card id matches';
     }
 


### PR DESCRIPTION
 * check for either of the valid succesful values, 'paid' for Stripe API versions before 2015-02-18 or 'succeeded' for versions after <https://stripe.com/docs/upgrades#2015-02-18>