### PR TITLE
deprecate direct handling of PANs

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -150,7 +150,7 @@ L<https://stripe.com/docs/api#create_charge>
 
 =item * customer - StripeCustomerId - customer to charge - optional
 
-=item * card - StripeTokenId, StripeCardId or HashRef - card to use - optional
+=item * card - StripeTokenId or StripeCardId - card to use - optional
 
 =item * description - Str - description for the charge - optional
 
@@ -256,7 +256,7 @@ L<https://stripe.com/docs/api#create_customer>
 
 =item * account_balance - Int, optional
 
-=item * card - L<Net::Stripe::Token>, StripeTokenId or HashRef, default card for the customer, optional
+=item * card - L<Net::Stripe::Token> or StripeTokenId, default card for the customer, optional
 
 =item * coupon - Str, optional
 
@@ -277,7 +277,7 @@ L<https://stripe.com/docs/api#create_customer>
 Returns a L<Net::Stripe::Customer> object.
 
   my $customer = $stripe->post_customer(
-    card => $fake_card,
+    card => $token_id,
     email => 'stripe@example.com',
     description => 'Test for Net::Stripe',
   );
@@ -386,7 +386,7 @@ L<https://stripe.com/docs/api/cards/create#create_card>
 
 =item * customer - L<Net::Stripe::Customer> or StripeCustomerId
 
-=item * card - L<Net::Stripe::Card>, L<Net::Stripe::Token>, StripeTokenId or HashRef
+=item * card - L<Net::Stripe::Token> or StripeTokenId
 
 =back
 
@@ -477,7 +477,7 @@ L<https://stripe.com/docs/api#create_subscription>
 
 =item * subscription - L<Net::Stripe::Subscription> or Str
 
-=item * card - L<Net::Stripe::Card>, L<Net::Stripe::Token>, Str or HashRef, default card for the customer, optional
+=item * card - L<Net::Stripe::Card>, L<Net::Stripe::Token> or Str, default card for the customer, optional
 
 =item * coupon - Str, optional
 
@@ -534,22 +534,6 @@ Returns a L<Net::Stripe::Subscription> object.
   $stripe->delete_subscription(customer => $customer, subscription => $subscription);
 
 =head1 Token Methods
-
-=head2 post_token
-
-Create a new token.
-
-L<https://stripe.com/docs/api#create_card_token>
-
-=over
-
-=item * card - L<Net::Stripe::Card> or HashRef
-
-=back
-
-Returns a L<Net::Stripe::Token>.
-
-  $stripe->post_token(card => $test_card);
 
 =head2 get_token
 
@@ -988,6 +972,22 @@ Returns hashref of the form
 =head1 RELEASE NOTES
 
 =head2 Version 0.40
+
+=head3 BREAKING CHANGES
+
+=over
+
+=item deprecate direct handling of PANs
+
+Stripe strongly discourages direct handling of PANs (primary account numbers),
+even in test mode, and returns invalid_request_error when passing PANs to the
+API from accounts that were created after October 2017. In live mode, all
+tokenization should be performed via client-side libraries because direct
+handling of PANs violates PCI compliance. So we have removed the methods and
+parameter constraints that allow direct handling of PANs and updated the
+unit tests appropriately.
+
+=back
 
 =head3 BUG FIXES
 


### PR DESCRIPTION
 * Stripe strongly discourages direct handling of PANs (primary account numbers), even in test mode
 * accounts created after October 2017 return an invalid_request_error when passing PANs
 * removed the methods and parameter constraints that allow direct handling of PANs and their associated unit tests
 * updated the unit tests to use test tokens instead of card numbers