### PR TITLE
remove manual serialization in _get_collections() and _get_with_args()

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -1091,6 +1091,25 @@ There is now a dedicated block in convert_to_form_fields for this operation.
 This update was necessary because of the addition of update_card(), which
 accepts a card hashref, which may include metadata.
 
+=item encode objects in convert_to_form_fields()
+
+We removed the nested tertiary operator in _post() and updated
+convert_to_form_fields() so that it now handles encoding of objects, both
+top-level and nested. This streamlines the hashref vs object serailizing
+code, making it easy to adapt to other methods.
+
+=item remove manual serialization in _get_collections() and _get_with_args()
+
+We were using string contatenation to both serilize the individual query args,
+in _get_collections(), and to join the individual query args together, in
+_get_with_args(). This also involved some unnecessary duplication of the
+logic that convert_to_form_fields() was already capable of handling. We now
+use convert_to_form_fields() to process the passed data, and L<URI> to
+encode and serialize the query string. Along with other updates to
+convert_to_form_fields(), _get() can now easily handle the same calling
+form as _post(), eliminating the need for _get_collections() and
+_get_with_args(). We have also updated _delete() accordingly.
+
 =back
 
 =head3 UPDATES

--- a/lib/Net/Stripe/TypeConstraints.pm
+++ b/lib/Net/Stripe/TypeConstraints.pm
@@ -32,4 +32,13 @@ subtype 'StripeCustomerId',
         sprintf( "Value '%s' must be a customer id string of the form cus_.+", $_ );
     };
 
+subtype 'StripeResourceObject',
+    as 'Object',
+    where {
+        ( $_->isa( 'Net::Stripe::Resource' ) || $_->isa( 'Net::Stripe::Card' ) ) && $_->can( 'form_fields' )
+    },
+    message {
+        sprintf( "Value '%s' must be an object that inherits from Net::Stripe::Resource with a 'form_fields' method", $_ );
+    };
+
 1;

--- a/t/live.t
+++ b/t/live.t
@@ -1035,6 +1035,7 @@ Customers: {
             is $other_dsubs->status, 'active', 'subscription is still active';
             ok $other_dsubs->canceled_at, 'has canceled_at';
             ok !$other_dsubs->ended_at, 'does not have ended_at (not at period end yet)';
+            ok $other_dsubs->cancel_at_period_end, 'cancel_at_period_end';
 
             my $priceyplan = $stripe->post_plan(
                 id => "pricey-$future_ymdhms",


### PR DESCRIPTION
 * update convert_to_form_fields() to handle objects
 * use convert_to_form_fields() for processing passed data and URI for encoding, elminating _get_collections() and _get_with_args()
 * remove manual serialization in _delete()
 * add unit tests for code path to be deprecated later
 * closes <https://github.com/lukec/stripe-perl/issues/167>