### PR TITLE
extraneous request in _get_all()

### DIFF
--- a/lib/Net/Stripe.pm
+++ b/lib/Net/Stripe.pm
@@ -3638,6 +3638,9 @@ method _get_all(
                     ( $list, $page )
                 ],
             );
+
+            last unless $page->has_more;
+
         }
     }
     return $list;


### PR DESCRIPTION
* relying on `is_empty()` requires an extraneous API request
* after merging lists, use `has_more()` to exit loop
* closes <https://github.com/lukec/stripe-perl/issues/210>